### PR TITLE
Add Axiom CLI to global packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,7 @@
     tplResolverFile = "resolver/tpl"; # serves *.tpl
 
     overlay = final: prev: {
+      axiomCli = prev.callPackage ./pkgs/axiom-cli.nix {};
       homebridge = prev.callPackage ./pkgs/homebridge.nix {};
       mole = prev.callPackage ./pkgs/mole.nix {};
       rampCli = prev.callPackage ./pkgs/ramp-cli.nix {};
@@ -371,6 +372,7 @@
       commonPackages =
         (with pkgs; [
           _1password-cli
+          axiomCli
           bash
           bash-completion
           claude-code

--- a/pkgs/axiom-cli.nix
+++ b/pkgs/axiom-cli.nix
@@ -1,0 +1,52 @@
+{
+  fetchzip,
+  lib,
+  stdenvNoCC,
+}: let
+  version = "0.16.0";
+  sources = {
+    aarch64-darwin = {
+      url = "https://github.com/axiomhq/cli/releases/download/v${version}/axiom_${version}_darwin_arm64.tar.gz";
+      hash = "sha256-gQSYjTuPGnqu6mPoJuChOQoI30PbS+cop66coDyY9KE=";
+    };
+    x86_64-linux = {
+      url = "https://github.com/axiomhq/cli/releases/download/v${version}/axiom_${version}_linux_amd64.tar.gz";
+      hash = "sha256-PYVIljF7SCGXcLtqabpPudc608wUER9jGyyPtl82CCI=";
+    };
+  };
+  source =
+    sources.${stdenvNoCC.hostPlatform.system}
+    or (throw "axiom-cli is not packaged for ${stdenvNoCC.hostPlatform.system}");
+in
+  stdenvNoCC.mkDerivation {
+    pname = "axiom-cli";
+    inherit version;
+
+    src = fetchzip source;
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 axiom "$out/bin/axiom"
+      install -Dm644 LICENSE "$out/share/licenses/axiom-cli/LICENSE"
+
+      install -d "$out/share/man/man1"
+      install -m644 man/*.1 "$out/share/man/man1/"
+
+      install -Dm644 completions/axiom.bash "$out/share/bash-completion/completions/axiom"
+      install -Dm644 completions/_axiom "$out/share/zsh/site-functions/_axiom"
+      install -Dm644 completions/axiom.fish "$out/share/fish/vendor_completions.d/axiom.fish"
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Official Axiom command-line interface";
+      homepage = "https://github.com/axiomhq/cli";
+      license = lib.licenses.mit;
+      mainProgram = "axiom";
+      platforms = builtins.attrNames sources;
+    };
+  }


### PR DESCRIPTION
## Summary

- package the official Axiom CLI v0.16.0 release for aarch64-darwin and x86_64-linux with pinned source hashes
- install the binary, license, man pages, and Bash, Zsh, and Fish completions
- add the CLI to the shared global package environment

## Why

This makes the supported hosts able to authenticate to Axiom and query logs without a one-off installation.

## Validation

- `nix flake check --all-systems`
- `nix build . --no-link`
- built global environment reports `Axiom CLI, release 0.16.0`
- verified packaged man page and shell completions
- `just fmt-check`
- `git diff --check`

## Existing issue

`just lint` still reports 28 Ruff findings in untouched Python scripts on current `main`; this PR does not modify those files.